### PR TITLE
Fix heading capitalization

### DIFF
--- a/_drafts/2019-08-09-getting-started.md
+++ b/_drafts/2019-08-09-getting-started.md
@@ -107,7 +107,7 @@ Before deploying, check the `_config.yml`{: .filepath} file and ensure the `url`
 
 Now you can choose _ONE_ of the following methods to deploy your Jekyll site.
 
-### Deploy Using Github Actions
+### Deploy Using GitHub Actions
 
 Prepare the following:
 

--- a/_drafts/backup/2019-08-09-getting-started.md
+++ b/_drafts/backup/2019-08-09-getting-started.md
@@ -107,7 +107,7 @@ Before deploying, check the `_config.yml`{: .filepath} file and ensure the `url`
 
 Now you can choose _ONE_ of the following methods to deploy your Jekyll site.
 
-### Deploy Using Github Actions
+### Deploy Using GitHub Actions
 
 Prepare the following:
 


### PR DESCRIPTION
## Summary
- use proper GitHub capitalization in deploy section headings

## Testing
- `grep -n "Deploy Using" -n _drafts/2019-08-09-getting-started.md`
- `grep -n "Deploy Using" -n _drafts/backup/2019-08-09-getting-started.md`